### PR TITLE
Bump dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "findup-sync": "~0.1.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.0rc4",
-    "grunt-contrib-jshint": "~0.1.0"
+    "grunt": "~0.4.0",
+    "grunt-contrib-jshint": "~0.2.0"
   }
 }


### PR DESCRIPTION
- Removes the prerelease dependency for grunt
- bump jshint to use version with v1.0.0 dependency
- Left nopt at v1 although v2 is out now
