### PR TITLE
Small tweak to package.json makes 'npm test' work again in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "./bin/grunt test"
+    "test": "node bin/grunt test"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
Windows doesn't handle dot slash notation well, so I tweaked the `test` script in `package.json`. I'm happy to report that all tests pass in Windows!

```
$ npm test

> grunt-cli@0.1.7 test c:\Documents and Settings\apenneba\Desktop\src\grunt-cli
> node bin/grunt test

Running "jshint:all" (jshint) task
>> 5 files lint free.
```
