### PR TITLE
Bash completion

### DIFF
--- a/completion/bash
+++ b/completion/bash
@@ -14,27 +14,10 @@
 #
 # eval "$(grunt --completion=bash)"
 
-# Search the current directory and all parent directories for a gruntfile.
-function _grunt_gruntfile() {
-  local curpath="$PWD"
-  while [[ -n "$curpath" ]]; do
-    for gruntfile in "$curpath/"{G,g}runtfile.{js,coffee}; do
-      if [[ -e "$gruntfile" ]]; then
-        echo "$gruntfile"
-        return
-      fi
-    done
-    curpath="${curpath%/*}"
-  done
-  return 1
-}
-
 # Enable bash autocompletion.
 function _grunt_completions() {
   # The currently-being-completed word.
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  # The current gruntfile, if it exists.
-  local gruntfile="$(_grunt_gruntfile)"
   # The current grunt version, available tasks, options, etc.
   local gruntinfo="$(grunt --version --verbose 2>/dev/null)"
   # Options and tasks.


### PR DESCRIPTION
- Removes unused function from Bash completions
  - (Since the 5289136 was part of that function, this also allows Zsh to parse the completions after `autoload bashcompinit && bashcompinit`)

Separated these into another PR per https://github.com/gruntjs/grunt-cli/pull/24#issuecomment-20758170.
