### PR TITLE
Implement wait-to-execute feature

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -39,5 +39,15 @@ try {
   }
 }
 
-// Everything looks good. Require local grunt and run it.
-require(gruntpath).cli();
+if (process.argv.indexOf('--wait-to-execute') === -1) {
+  // Everything looks good. Require local grunt and run it.
+  require(gruntpath).cli();
+} else {
+  // Wait to receive a command to execute grunt
+  process.on('message', function(msg) {
+    if (msg === 'execute') {
+      require(gruntpath).cli();
+    }
+  });
+  setInterval(function() {}, 200);
+}


### PR DESCRIPTION
I'm working on ways to make spawning faster with the watch task. One of the ways is to preemptively spawn grunt and then have it wait for a signal to run the task. Then the watch task could fork grunt upon init and at the end of each run, rather than before. The idea is from this issue: https://github.com/gruntjs/grunt-contrib-watch/issues/234#issuecomment-27819213

Benchmarking this is showing a ~200ms response improvement and ~300ms on Windows.

This feature could totally be done as another library too. I just wanted to check if it was worth implementing here instead.

Here is an example on how this would be used:

``` js
var fork = require('child_process').fork;
var path = require('path');

// create a fork that waits to be executed
var cli = path.join(__dirname, 'node_modules', '.bin', 'grunt');
var child = fork(cli, ['jshint', '--wait-to-execute']);

setTimeout(function() {
  // 5s later, run the jshint task
  // or my use case, when the watch has been triggered
  child.send('execute');
}, 5000);
```
