### PR TITLE
If a --gruntfile is passed in with --base use basedir from gruntfile

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -23,7 +23,7 @@ if ('completion' in options) {
   completion.print(options.completion);
 } else if (options.version) {
   info.version();
-} else if (options.base) {
+} else if (options.base && !options.gruntfile) {
   basedir = path.resolve(options.base);
 } else if (options.gruntfile) {
   basedir = path.resolve(path.dirname(options.gruntfile));


### PR DESCRIPTION
This is a fix for cases that use

`grunt <task> --src=./path/ --base=./ --gruntfile=/path/to/Gruntfile.js`. The functionality broke after https://github.com/gruntjs/grunt-cli/issues/26 was fixed
