### PR TITLE
use a global grunt install if no local install found

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -33,6 +33,11 @@ try {
   gruntpath = resolve('grunt', {basedir: basedir});
 } catch (ex) {
   gruntpath = findup('lib/grunt.js');
+  // look for global grunt install
+  if (!gruntpath)
+    try {
+      gruntpath = require.resolve('grunt');
+    } catch (ex) { }
   // No grunt install found!
   if (!gruntpath) {
     if (options.version) { process.exit(); }


### PR DESCRIPTION
There's a problem with grunt-cli. It doesn't recognize a globally installed grunt, so one has to reinstall grunt for each project separately, thereby littering the project's file space. This patch fixes this issue.
