### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,7 @@
   "version": "0.1.13",
   "author": "Grunt Team",
   "repository": "gruntjs/grunt-cli",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/gruntjs/grunt-cli/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/