### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install this globally and you'll have access to the `grunt` command anywhere on 
 npm install -g grunt-cli
 ```
 
-**Note:** The job of the `grunt` command is to load and run the version of Grunt you have installed locally to your project, irrespective of its version.  Starting with Grunt v0.4, you should never install Grunt itself globally.  For more information about why, [please read this](http://blog.nodejs.org/2011/03/23/npm-1-0-global-vs-local-installation).
+**Note:** The job of the `grunt` command is to load and run the version of Grunt you have installed locally to your project, irrespective of its version.  Starting with Grunt v0.4, you should never install Grunt itself globally.  For more information about why, [please read this](http://nodejs.org/en/blog/npm/npm-1-0-global-vs-local-installation).
 
 See the [Getting Started](http://gruntjs.com/getting-started) guide for more information.
 


### PR DESCRIPTION
The *nodejs.org* "global v local" link in your README is broken - I'm not sure why. The URL I've linked to surely has the same content as the original.