### PR TITLE
Improved error message when grunt isn't installed

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -42,9 +42,9 @@ exports.helpHeader = function() {
 // Help footer.
 exports.helpFooter = function() {
   [
-    'If you\'re seeing this message, either a Gruntfile wasn\'t found or grunt',
-    'hasn\'t been installed locally to your project. For more information about',
-    'installing and configuring grunt, please see the Getting Started guide:',
+    'If you\'re seeing this message, grunt hasn\'t been installed locally to',
+    'your project. For more information about installing and configuring grunt,',
+    'please see the Getting Started guide:',
     '',
     'http://gruntjs.com/getting-started',
   ].forEach(function(str) { console.log(str); });


### PR DESCRIPTION
- Error message suggests the possibility that `Gruntfile.js` wasn't found
  - Misleading, as this error message only appears when `grunt` hasn't been found/installed
  - Grunt itself has an error safeguard for detecting an absent `Gruntfile.js`
  - Improved error message makes debugging easier