### PR TITLE
Use shared grunt-known-options

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -14,7 +14,6 @@ var completion = require('../lib/completion');
 var info = require('../lib/info');
 var path = require('path');
 
-
 var basedir = process.cwd();
 var gruntpath;
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,10 +11,19 @@
 
 // External lib.
 var nopt = require('nopt');
+var gruntOptions = require('grunt-known-options');
 
-// CLI options we care about.
-exports.known = {help: Boolean, version: Boolean, completion: String};
-exports.aliases = {h: '--help', V: '--version', v: '--verbose'};
+// Parse `gruntOptions` into a form that nopt can handle.
+exports.aliases = {};
+exports.known = {};
+
+Object.keys(gruntOptions).forEach(function(key) {
+  var short = gruntOptions[key].short;
+  if (short) {
+    exports.aliases[short] = '--' + key;
+  }
+  exports.known[key] = gruntOptions[key].type;
+});
 
 // Parse them and return an options object.
 Object.defineProperty(exports, 'options', {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "findup-sync": "~0.3.0",
+    "grunt-known-options": "~1.0.0",
     "nopt": "~3.0.6",
     "resolve": "~1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "findup-sync": "~0.3.0",
-    "grunt-known-options": "~1.0.0",
+    "grunt-known-options": "~1.1.0",
     "nopt": "~3.0.6",
     "resolve": "~1.1.0"
   },


### PR DESCRIPTION
Fixes GH-102

This uses the newly created https://github.com/gruntjs/grunt-known-options for sharing the known options between Grunt and grunt-cli. This makes the previous known Grunt options syntax backwards compatible: `grunt --gruntfile some/Gruntfile.js` vs `grunt --grunt=some/Gruntfile.js`. Both will work with this PR rather than just the later.

Unknown options in users Gruntfiles will still need to be aware of the new syntax though.

/cc @vladikoff @Arkni @EtienneMiret