### PR TITLE
cwd option should use existing base option

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -44,7 +44,7 @@ v8flags(function (err, v8flags) {
     v8flags: v8flags
   });
   Grunt.launch({
-    cwd: options.cwd,
+    cwd: options.base,
     configPath: options.gruntfile,
     require: options.require,
     verbose: options.verbose


### PR DESCRIPTION
Ref GH-121

I added a `cwd` option for setting the current working directory by mistake. We should instead using the existing [`base`](https://gruntjs.com/using-the-cli#base-b) option for this.