### PR TITLE
Update `v8flags` to support Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "interpret": "~1.1.0",
     "liftoff": "~2.5.0",
     "nopt": "~4.0.1",
-    "v8flags": "~3.0.2"
+    "v8flags": "~3.1.1"
   },
   "devDependencies": {
     "grunt": "~1.0.2",


### PR DESCRIPTION
With Node 10 (`v10.11.0` to be precise) I get the following error when running---among other commands---`grunt --force`:

```
/usr/bin/node: bad option: --force
```
This seems to be the fault of `v8flags`, somehow. This update fixes that.