### PR TITLE
Updated dependencies for v8flags to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "interpret": "~1.1.0",
     "liftup": "~3.0.1",
     "nopt": "~4.0.1",
-    "v8flags": "~3.2.0"
+    "v8flags": "^4.0.1"
   },
   "devDependencies": {
-    "grunt": "~1.3.0",
-    "grunt-contrib-jshint": "~3.0.0"
+    "grunt": "^1.6.1",
+    "grunt-contrib-jshint": "^3.2.0"
   },
   "files": [
     "bin",


### PR DESCRIPTION
The latest v8flags no longer uses an md5 hash but uses a FIPS compatible sha256 hash algorithm. This fix allows grunt-cli to work on a FIPS enabled system.