### PR TITLE
Update from nopt 4.x to nopt 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-known-options": "~2.0.0",
     "interpret": "~1.1.0",
     "liftup": "~3.0.1",
-    "nopt": "~4.0.1",
+    "nopt": "~5.0.0",
     "v8flags": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
installation of latest grunt-cli@1.4.2 produces a warning:

```
npm WARN deprecated osenv@0.1.5: This package is no longer supported.
```

This package is only used by nopt to call `os.homedir()` which has been stable since Node.js 2. It was removed https://github.com/npm/nopt/commit/5c0e45b2f94414c074270b133e90c77ec35f5a4b in nopt 5.0.0.

There are newer versions of nopt available, but those raise the required Node.js engine level. In order to make this safe to land, and easy to release, resolve the warning first by moving to nopt 5.0.0.